### PR TITLE
Revert "resolve #74 : 특정 분기 파싱 오류시 전체 실패하지 않도록 처리"

### DIFF
--- a/dart_fss/fs/extract.py
+++ b/dart_fss/fs/extract.py
@@ -4,7 +4,6 @@ import math
 import warnings
 import numpy as np
 import pandas as pd
-import traceback
 
 from typing import Union, List, Dict, Tuple, Pattern, Optional
 from collections import OrderedDict
@@ -491,22 +490,15 @@ def search_fs_table(tables: List, fs_tp: Tuple[str] = ('bs', 'is', 'cis', 'cf'),
     return fs_table
 
 
-def extract_fs_table(fs_table, fs_tp, separate: bool = False, lang: str = 'ko', report = None):
+def extract_fs_table(fs_table, fs_tp, separate: bool = False, lang: str = 'ko'):
     results = OrderedDict()
     for tp, table in fs_table.items():
         if tp in fs_tp:
-            df = None
             if table['table']:
-                try:
-                    columns = convert_thead_into_columns(fs_tp=tp, fs_table=table, separate=separate, lang=lang)
-                    df = convert_tbody_to_dataframe(columns=columns, fs_table=table)
-                except Exception as ex :
-                    traceback.print_exc()
-                    report_dict = None
-                    if report is not None :
-                        report_dict = report.to_dict()
-                    warnings_text = 'Unable to extract a {} type financial statement. : {}'.format(tp, report_dict)
-                    warnings.warn(warnings_text, RuntimeWarning)
+                columns = convert_thead_into_columns(fs_tp=tp, fs_table=table, separate=separate, lang=lang)
+                df = convert_tbody_to_dataframe(columns=columns, fs_table=table)
+            else:
+                df = None
             results[tp] = df
     return results
 
@@ -600,7 +592,7 @@ def analyze_html(report: Report, fs_tp: Tuple[str] = ('bs', 'is', 'cis', 'cf'),
     if count == 0:
         return None
 
-    extract_results = extract_fs_table(fs_table=fs_table, fs_tp=fs_tp, separate=separate, lang=lang, report=report)
+    extract_results = extract_fs_table(fs_table=fs_table, fs_tp=fs_tp, separate=separate, lang=lang)
     return extract_results
 
 
@@ -1310,42 +1302,32 @@ def extract(corp_code: str,
                 for _ in tqdm(range(length), desc='{} reports'.format(all_report_name[idx]), unit='report'):
                     report = reports.pop(0)
                     if statements is None:
-                        try :
-                            statements = analyze_report(report=report,
-                                                        fs_tp=fs_tp,
-                                                        separate=separate,
-                                                        lang=lang,
-                                                        separator=separator)
-                            if statements is None:
-                                warnings_text = 'Unable to extract financial statements: {}.'.format(report.to_dict())
-                                warnings.warn(warnings_text, RuntimeWarning)
-                            else:
-                                if separate is False and all([statements[tp] is None for tp in statements]):
-                                    raise NotFoundConsolidated('Could not find consolidated financial statements')
-                                # initialize label dictionary
-                                label_df = init_label(statements, fs_tp=fs_tp)
-                        except Exception as ex :
-                            traceback.print_exc()
+                        statements = analyze_report(report=report,
+                                                    fs_tp=fs_tp,
+                                                    separate=separate,
+                                                    lang=lang,
+                                                    separator=separator)
+                        if statements is None:
                             warnings_text = 'Unable to extract financial statements: {}.'.format(report.to_dict())
                             warnings.warn(warnings_text, RuntimeWarning)
+                        else:
+                            if separate is False and all([statements[tp] is None for tp in statements]):
+                                raise NotFoundConsolidated('Could not find consolidated financial statements')
+                            # initialize label dictionary
+                            label_df = init_label(statements, fs_tp=fs_tp)
 
                     else:
-                        try :
-                            nstatements = analyze_report(report=report,
-                                                         fs_tp=fs_tp,
-                                                         separate=separate,
-                                                         lang=lang,
-                                                         separator=separator,
-                                                         dataset=dataset)
-                            if nstatements is None:
-                                warnings_text = 'Unable to extract financial statements: {}.'.format(report.to_dict())
-                                warnings.warn(warnings_text, RuntimeWarning)
-                            else:
-                                statements, label_df = merge_fs(statements, nstatements, fs_tp=fs_tp, label_df=label_df)
-                        except Exception as ex :
-                            traceback.print_exc()
+                        nstatements = analyze_report(report=report,
+                                                     fs_tp=fs_tp,
+                                                     separate=separate,
+                                                     lang=lang,
+                                                     separator=separator,
+                                                     dataset=dataset)
+                        if nstatements is None:
                             warnings_text = 'Unable to extract financial statements: {}.'.format(report.to_dict())
                             warnings.warn(warnings_text, RuntimeWarning)
+                        else:
+                            statements, label_df = merge_fs(statements, nstatements, fs_tp=fs_tp, label_df=label_df)
 
         # Spinner enable
         dart.utils.spinner.spinner_enable = True


### PR DESCRIPTION
Reverts josw123/dart-fss#80

아래와 같이 4개의 테스트에서 통과하지 못하였기 때문에 Revert합니다.

Failed: Test failed: corp_code='01183407', corp_name='이십일스토어', fs_tp='bs', start_dt='20120101', report_tp='annual', date='20161231', column='label_ko',item='I.유동자산', actual='None', expected='5531436227'

Failed: Test failed: corp_code='00126186', corp_name='삼성에스디에스', fs_tp='bs', start_dt='20130813', report_tp='quarter', date='20130630', column='label_ko',item='유동자산', actual='None', expected='2602291807082'

Failed: Test failed: corp_code='00547583', corp_name='하나금융지주', fs_tp='bs', start_dt='20120101', report_tp='annual', date='20100101', column='label_ko',item='부채총계', actual='None', expected='139823866000000'

Failed: Test failed: corp_code='00123772', corp_name='부국증권', fs_tp='bs', start_dt='20200101', report_tp='annual', date='20201231', column='label_ko',item='부채및자본총계', actual='None', expected='1608864797228'
