### PR TITLE
Develop

### DIFF
--- a/dart_fss/tests/test_corp.py
+++ b/dart_fss/tests/test_corp.py
@@ -32,7 +32,7 @@ def test_find_by_product(corp_list):
 def test_find_by_sector(corp_list):
     res = corp_list.find_by_sector('1차 비철금속 제조업')
     actual = len(res)
-    expected = 22  # The number may vary as the corp list is updated
+    expected = 23  # The number may vary as the corp list is updated
     assert actual == expected
 
 

--- a/dart_fss/tests/test_dart_xbrl.py
+++ b/dart_fss/tests/test_dart_xbrl.py
@@ -1,0 +1,59 @@
+from dart_fss.xbrl.dart_xbrl import DartXbrl
+
+
+def _make_xbrl(
+    tables=None,
+    consolidated_financial_statement=None,
+    separate_financial_statement=None,
+    consolidated_income_statement=None,
+    separate_income_statement=None,
+    consolidated_changes_in_equity=None,
+    separate_changes_in_equity=None,
+    consolidated_cash_flows=None,
+    separate_cash_flows=None,
+):
+    xbrl = DartXbrl.__new__(DartXbrl)
+    xbrl._tables = tables
+    xbrl.get_financial_statement = lambda separate=False: (
+        separate_financial_statement if separate else consolidated_financial_statement
+    )
+    xbrl.get_income_statement = lambda separate=False: (
+        separate_income_statement if separate else consolidated_income_statement
+    )
+    xbrl.get_changes_in_equity = lambda separate=False: (
+        separate_changes_in_equity if separate else consolidated_changes_in_equity
+    )
+    xbrl.get_cash_flows = lambda separate=False: (
+        separate_cash_flows if separate else consolidated_cash_flows
+    )
+    return xbrl
+
+
+def test_is_empty_returns_true_without_tables():
+    xbrl = _make_xbrl(tables=[])
+
+    assert xbrl.is_empty() is True
+
+
+def test_is_empty_returns_true_without_financial_statement_tables():
+    xbrl = _make_xbrl(tables=[object()])
+
+    assert xbrl.is_empty() is True
+
+
+def test_is_empty_returns_false_for_consolidated_only_statement():
+    xbrl = _make_xbrl(
+        tables=[object()],
+        consolidated_financial_statement=[object()],
+    )
+
+    assert xbrl.is_empty() is False
+
+
+def test_is_empty_returns_false_for_separate_only_statement():
+    xbrl = _make_xbrl(
+        tables=[object()],
+        separate_financial_statement=[object()],
+    )
+
+    assert xbrl.is_empty() is False

--- a/dart_fss/tests/test_xbrl_helper.py
+++ b/dart_fss/tests/test_xbrl_helper.py
@@ -1,0 +1,85 @@
+import math
+from datetime import datetime
+from types import SimpleNamespace
+
+from dart_fss.xbrl.helper import get_value_from_dataset
+
+
+def _make_fact(concept_id, value, decimals='0'):
+    return SimpleNamespace(
+        concept=SimpleNamespace(id=concept_id),
+        value=value,
+        decimals=decimals,
+    )
+
+
+def _make_cls(cls_id, instant='20250930'):
+    return {
+        'cls_id': cls_id,
+        'instant_datetime': datetime.strptime(instant, '%Y%m%d'),
+        'start_datetime': None,
+        'end_datetime': None,
+        'label': {'ko': {'ko': '연결', 'en': 'Consolidated'}},
+    }
+
+
+def test_string_value_is_preserved():
+    concept_id = 'ifrs-full_RestrictedCash'
+    text = '사용제한 예치금에는 현금및현금성자산의 정의를 충족하는 지준예치금 등이 제외되어 있습니다.'
+    cls = _make_cls('ctx_2025Q3')
+    dataset = {'ctx_2025Q3': [_make_fact(concept_id, text)]}
+
+    result = get_value_from_dataset(cls, dataset, concept_id)
+    assert result == [text]
+
+
+def test_number_wins_over_text_on_duplicate_title():
+    concept_id = 'ifrs-full_Cash'
+    cls_a = _make_cls('ctx_a')
+    cls_b = _make_cls('ctx_b')
+    dataset = {
+        'ctx_a': [_make_fact(concept_id, '사용제한 예치금')],
+        'ctx_b': [_make_fact(concept_id, '1234567890')],
+    }
+
+    result = get_value_from_dataset([cls_a, cls_b], dataset, concept_id)
+    assert result == [1234567890.0]
+
+
+def test_text_after_number_no_typeerror():
+    """Regression for #172 and the 하나금융지주 2025 Q3 case: a text fact arriving
+    after a numeric fact for the same title used to crash math.isnan() on line 179."""
+    concept_id = 'ifrs-full_Cash'
+    cls_a = _make_cls('ctx_a')
+    cls_b = _make_cls('ctx_b')
+    dataset = {
+        'ctx_a': [_make_fact(concept_id, '1234567890')],
+        'ctx_b': [_make_fact(concept_id, '사용제한 예치금')],
+    }
+
+    result = get_value_from_dataset([cls_a, cls_b], dataset, concept_id)
+    assert result == [1234567890.0]
+
+
+def test_numeric_string_still_parses():
+    concept_id = 'ifrs-full_Cash'
+    cls = _make_cls('ctx_x')
+    dataset = {'ctx_x': [_make_fact(concept_id, '987654321')]}
+    assert get_value_from_dataset(cls, dataset, concept_id) == [987654321.0]
+
+
+def test_none_value_returns_nan():
+    concept_id = 'ifrs-full_Cash'
+    cls = _make_cls('ctx_n')
+    dataset = {'ctx_n': [_make_fact(concept_id, None)]}
+    result = get_value_from_dataset(cls, dataset, concept_id)
+    assert len(result) == 1 and math.isnan(result[0])
+
+
+def test_currency_unit_branch_safe_on_text():
+    concept_id = 'ifrs-full_Cash'
+    text = '사용제한 예치금'
+    cls = _make_cls('ctx_u')
+    dataset = {'ctx_u': [_make_fact(concept_id, text, decimals=None)]}
+    result = get_value_from_dataset(cls, dataset, concept_id, label_ko='현금및현금성자산(단위:원)')
+    assert result == [text]

--- a/dart_fss/xbrl/dart_xbrl.py
+++ b/dart_fss/xbrl/dart_xbrl.py
@@ -35,9 +35,13 @@ class DartXbrl(object):
             return True
 
         data = [
+            self.get_financial_statement(False),
             self.get_financial_statement(True),
+            self.get_income_statement(False),
             self.get_income_statement(True),
+            self.get_changes_in_equity(False),
             self.get_changes_in_equity(True),
+            self.get_cash_flows(False),
             self.get_cash_flows(True),
         ]
         return all(x is None for x in data)

--- a/dart_fss/xbrl/helper.py
+++ b/dart_fss/xbrl/helper.py
@@ -136,8 +136,18 @@ def get_value_from_dataset(classification, dataset, concept_id, label_ko=None, s
     def str_to_float(val, w=1.0):
         try:
             return float(val) * w
-        except ValueError:
-            return val
+        except (ValueError, TypeError):
+            return val if isinstance(val, str) else float('nan')
+
+    def is_number(val):
+        try:
+            math.isnan(val)
+            return True
+        except TypeError:
+            return False
+
+    def is_nan(val):
+        return is_number(val) and math.isnan(val)
 
     if isinstance(classification, dict):
         classification = [classification]
@@ -164,10 +174,10 @@ def get_value_from_dataset(classification, dataset, concept_id, label_ko=None, s
             if str_compare_func(data.concept.id, concept_id):
                 value = str_to_float(data.value, sign)
                 # XBRL 내부 주당이익에서 발생하는 오류 수정을 위한 코드
-                if currency_unit is not None:
+                if currency_unit is not None and is_number(value):
                     decimals = str_to_float(data.decimals)
                     # decimals이 없을 경우 0으로 처리
-                    if math.isinf(decimals) or math.isnan(decimals):
+                    if not is_number(decimals) or math.isinf(decimals) or math.isnan(decimals):
                         decimals = 0
                     value = value * pow(10, decimals)
                     value = value * currency_unit
@@ -176,7 +186,9 @@ def get_value_from_dataset(classification, dataset, concept_id, label_ko=None, s
         title = get_title(cls, 'en')
         if title in added_title:
             index = added_title.index(title)
-            if not math.isnan(value):
+            if is_number(value) and not is_nan(value):
+                results[index] = value
+            elif not is_number(value) and is_nan(results[index]):
                 results[index] = value
         else:
             results.append(value)


### PR DESCRIPTION
- XBRL 데이터 추출 시 문자열 fact가 포함된 경우 `math.isnan()` 호출로 `TypeError`가 발생하던 문제 수정
  - Fixes #172
  - Fixes #202

- `DartXbrl.is_empty()`가 개별 재무제표만 확인하던 문제를 수정하여 연결/개별 재무제표를 모두 기준으로 유효성을 판단하도록 변경
  - Fixes #203

- 최신 corp list 데이터에 맞춰 sector 검색 테스트 기대값 수정

- 테스트
  - `python -m pytest -q`
  - `144 passed, 16 skipped`