### PR TITLE
Improve role name search fallback and test company lookup

### DIFF
--- a/dart_fss/tests/test_dart_xbrl.py
+++ b/dart_fss/tests/test_dart_xbrl.py
@@ -1,3 +1,7 @@
+from datetime import datetime
+
+import pytest
+
 from dart_fss.xbrl.dart_xbrl import DartXbrl
 
 
@@ -55,5 +59,185 @@ def test_is_empty_returns_false_for_separate_only_statement():
         tables=[object()],
         separate_financial_statement=[object()],
     )
+
+    assert xbrl.is_empty() is False
+
+
+class _FakeTable:
+    def __init__(self, code, definition, concept_values=None, cls=None):
+        self.code = code
+        self.definition = definition
+        self._concept_values = concept_values or {}
+        self.cls = cls if cls is not None else []
+
+    def get_value_by_concept_id(self, concept_id, **kwargs):
+        return self._concept_values.get(concept_id, {})
+
+
+def _make_xbrl_with_tables(tables):
+    xbrl = DartXbrl.__new__(DartXbrl)
+    xbrl._tables = tables
+    return xbrl
+
+
+def _info_table(concept_values=None, cls=None):
+    return _FakeTable(
+        'D999007',
+        '[D999007] 보고서정보 - 재무제표 정보 | Financial Statement Information',
+        concept_values=concept_values,
+        cls=cls,
+    )
+
+
+_BS_CONSOLIDATED = _FakeTable(
+    'D210000',
+    '[D210000] 재무상태표, 유동/비유동법 - 연결 | Statement of financial position, '
+    'current/non-current - Consolidated financial statements')
+_BS_SEPARATE = _FakeTable(
+    'D210005',
+    '[D210005] 재무상태표, 유동/비유동법 - 별도 | Statement of financial position, '
+    'current/non-current - Separated financial statements')
+_IS_CONSOLIDATED = _FakeTable(
+    'D310000',
+    '[D310000] 손익계산서, 기능별 분류 - 연결 | Income statement, by function of expense '
+    '- Consolidated financial statements')
+_CIS_CONSOLIDATED = _FakeTable(
+    'D410000',
+    '[D410000] 포괄손익계산서 - 연결 | Statement of comprehensive income '
+    '- Consolidated financial statements')
+_SINGLE_CIS_CONSOLIDATED = _FakeTable(
+    'D432410',
+    '[D432410] 단일 포괄손익계산서, 기능별 분류 - 연결 | Statement of comprehensive income, '
+    'single statement, by function of expense - Consolidated financial statements')
+_CIE_CONSOLIDATED = _FakeTable(
+    'D610000',
+    '[D610000] 자본변동표 - 연결 | Statement of changes in equity '
+    '- Consolidated financial statements')
+_CF_CONSOLIDATED = _FakeTable(
+    'D520000',
+    '[D520000] 현금흐름표, 간접법 - 연결 | Statement of cash flows, indirect method '
+    '- Consolidated financial statements')
+_CF_SEPARATE = _FakeTable(
+    'D520005',
+    '[D520005] 현금흐름표, 간접법 - 별도 | Statement of cash flows, indirect method '
+    '- Separated financial statements')
+_CF_NOTE_CONSOLIDATED = _FakeTable(
+    'D851100',
+    '[D851100] 35. 현금흐름표 - 연결 | 35. Cash flow statement '
+    '- Consolidated financial statements')
+
+_BS_CONCEPT = 'dart-gcd_StatementOfFinancialPosition'
+_CONSOLIDATED_KEY = ('20241231', ('Consolidated financial statements',))
+_SEPARATE_KEY = ('20241231', ('Separated financial statements',))
+
+
+def test_get_statement_normal_path_unchanged():
+    info = _info_table(concept_values={_BS_CONCEPT: {_CONSOLIDATED_KEY: 'D1001'}})
+    xbrl = _make_xbrl_with_tables([_BS_CONSOLIDATED, info])
+
+    tables = xbrl.get_financial_statement(separate=False)
+    assert [t.code for t in tables] == ['D210000']
+
+
+def test_get_statement_fallback_when_d999007_empty():
+    xbrl = _make_xbrl_with_tables([_BS_CONSOLIDATED, _BS_SEPARATE, _info_table()])
+
+    consolidated = xbrl.get_financial_statement(separate=False)
+    assert [t.code for t in consolidated] == ['D210000']
+
+    separate = xbrl.get_financial_statement(separate=True)
+    assert [t.code for t in separate] == ['D210005']
+
+
+def test_get_statement_fallback_filters_annotation_roles():
+    xbrl = _make_xbrl_with_tables(
+        [_CF_CONSOLIDATED, _CF_NOTE_CONSOLIDATED, _info_table()])
+
+    tables = xbrl.get_cash_flows(separate=False)
+    assert [t.code for t in tables] == ['D520000']
+
+
+def test_get_statement_fallback_none_when_separate_only():
+    xbrl = _make_xbrl_with_tables([_BS_SEPARATE, _info_table()])
+
+    assert xbrl.get_financial_statement(separate=False) is None
+
+
+def test_get_statement_no_fallback_when_d999007_says_separate_only():
+    info = _info_table(concept_values={_BS_CONCEPT: {_SEPARATE_KEY: 'D1001'}})
+    xbrl = _make_xbrl_with_tables([_BS_CONSOLIDATED, info])
+
+    assert xbrl.get_financial_statement(separate=False) is None
+
+
+def test_get_statement_fallback_income_statement_order():
+    xbrl = _make_xbrl_with_tables(
+        [_IS_CONSOLIDATED, _CIS_CONSOLIDATED, _info_table()])
+
+    tables = xbrl.get_income_statement(separate=False)
+    assert [t.code for t in tables] == ['D310000', 'D410000']
+
+
+def test_get_statement_fallback_single_comprehensive_income():
+    xbrl = _make_xbrl_with_tables([_SINGLE_CIS_CONSOLIDATED, _info_table()])
+
+    tables = xbrl.get_income_statement(separate=False)
+    assert [t.code for t in tables] == ['D432410']
+
+
+def test_get_statement_keyerror_path_filters_annotation():
+    info = _info_table(
+        concept_values={'dart-gcd_StatementOfCashFlows': {_CONSOLIDATED_KEY: 'D9999'}})
+    xbrl = _make_xbrl_with_tables([_CF_CONSOLIDATED, _CF_NOTE_CONSOLIDATED, info])
+
+    tables = xbrl.get_cash_flows(separate=False)
+    assert [t.code for t in tables] == ['D520000']
+
+
+def test_get_statement_none_when_d999007_missing():
+    xbrl = _make_xbrl_with_tables([_BS_CONSOLIDATED])
+
+    assert xbrl.get_financial_statement(separate=False) is None
+
+
+def test_exist_consolidated_fallback_true():
+    xbrl = _make_xbrl_with_tables([_BS_CONSOLIDATED, _BS_SEPARATE, _info_table()])
+
+    assert xbrl.exist_consolidated() is True
+
+
+def test_exist_consolidated_fallback_false():
+    xbrl = _make_xbrl_with_tables([_BS_SEPARATE, _info_table()])
+
+    assert xbrl.exist_consolidated() is False
+
+
+def test_exist_consolidated_raises_when_missing():
+    xbrl = _make_xbrl_with_tables([_BS_CONSOLIDATED])
+
+    with pytest.raises(ValueError):
+        xbrl.exist_consolidated()
+
+
+def test_exist_consolidated_normal_path():
+    cls = [{
+        'cls_id': 'ctx1',
+        'instant_datetime': datetime(2024, 12, 31),
+        'start_datetime': None,
+        'end_datetime': None,
+        'label': {'dim': {'ko': '연결재무제표', 'en': 'Consolidated financial statements'}},
+    }]
+    xbrl = _make_xbrl_with_tables([_BS_CONSOLIDATED, _info_table(cls=cls)])
+
+    assert xbrl.exist_consolidated() is True
+
+
+def test_is_empty_false_for_empty_d999007_with_statement_roles():
+    xbrl = _make_xbrl_with_tables([
+        _BS_CONSOLIDATED, _BS_SEPARATE,
+        _SINGLE_CIS_CONSOLIDATED, _CIE_CONSOLIDATED,
+        _CF_CONSOLIDATED, _CF_SEPARATE,
+        _info_table(),
+    ])
 
     assert xbrl.is_empty() is False

--- a/dart_fss/tests/test_errors.py
+++ b/dart_fss/tests/test_errors.py
@@ -29,5 +29,6 @@ def test_errors(dart):
 
 def test_not_found_consolidated(dart, corp_list):
     with pytest.raises(dart.errors.NotFoundConsolidated):
-        crp = corp_list.find_by_stock_code('204210')  # 종목명 변경
+        # 구 모두투어리츠: 사명 변경/상장폐지와 무관하도록 corp_code로 조회
+        crp = corp_list.find_by_corp_code('01035289')
         crp.extract_fs(bgn_de='20180101', end_de='20190101', skip_error=False)

--- a/dart_fss/tests/test_xbrl_helper.py
+++ b/dart_fss/tests/test_xbrl_helper.py
@@ -2,7 +2,9 @@ import math
 from datetime import datetime
 from types import SimpleNamespace
 
-from dart_fss.xbrl.helper import get_value_from_dataset
+from dart_fss.xbrl.helper import (get_value_from_dataset,
+                                  consolidated_code_to_role_number,
+                                  get_statement_role_numbers)
 
 
 def _make_fact(concept_id, value, decimals='0'):
@@ -83,3 +85,22 @@ def test_currency_unit_branch_safe_on_text():
     dataset = {'ctx_u': [_make_fact(concept_id, text, decimals=None)]}
     result = get_value_from_dataset(cls, dataset, concept_id, label_ko='현금및현금성자산(단위:원)')
     assert result == [text]
+
+
+def test_consolidated_code_to_role_number_regression():
+    assert consolidated_code_to_role_number('D2005') == ['D310000', 'D410000']
+    assert consolidated_code_to_role_number('D2005', separate=True) == ['D310005', 'D410005']
+    assert consolidated_code_to_role_number('D1001') == ['D210000']
+    assert consolidated_code_to_role_number('D1001', separate=True) == ['D210005']
+
+
+def test_get_statement_role_numbers():
+    consolidated = get_statement_role_numbers()
+    assert 'D210000' in consolidated
+    assert 'D520000' in consolidated
+    assert 'D851100' not in consolidated
+    assert 'D520005' not in consolidated
+
+    separated = get_statement_role_numbers(separate=True)
+    assert 'D520005' in separated
+    assert 'D520000' not in separated

--- a/dart_fss/xbrl/dart_xbrl.py
+++ b/dart_fss/xbrl/dart_xbrl.py
@@ -8,7 +8,16 @@ from arelle import ModelXbrl, XbrlConst
 
 from dart_fss.utils import str_compare, dict_to_html
 from dart_fss.xbrl.table import Table
-from dart_fss.xbrl.helper import get_title, consolidated_code_to_role_number
+from dart_fss.xbrl.helper import (get_title, consolidated_code_to_role_number,
+                                  get_statement_role_numbers)
+
+
+DATASET_TITLE = {
+    'dart-gcd_StatementOfFinancialPosition': '재무상태표',
+    'dart-gcd_StatementOfComprehensiveIncome': '손익계산서',
+    'dart-gcd_StatementOfChangesInEquity': '자본변동표',
+    'dart-gcd_StatementOfCashFlows': '현금흐름표',
+}
 
 
 class DartXbrl(object):
@@ -270,6 +279,9 @@ class DartXbrl(object):
         if info_table is None:
             raise ValueError("Missing consolidated financial statement information")
         cls_list = info_table.cls
+        if not cls_list:
+            # D999007에 fact가 없는 공시는 연결 재무상태표 Role 존재 여부로 판단
+            return self.get_financial_statement(separate=False) is not None
         for cls in cls_list:
             titles = get_title(cls, 'en')
             for title in titles:
@@ -280,6 +292,33 @@ class DartXbrl(object):
                     if regex.search(' '.join(title)):
                         return True
         return False
+
+    def _get_statement_by_name(self, concept_id: str, separate: bool = False) -> Union[List[Table], None]:
+        """ D999007 정보를 사용할 수 없을 때 Role 정의를 이용하여 재무제표를 검색하는 함수
+
+        Parameters
+        ----------
+        concept_id: str
+            dart-gcd_StatementOfFinancialPosition: 재무상태표
+            dart-gcd_StatementOfComprehensiveIncome: 포괄손익계산서
+            dart-gcd_StatementOfChangesInEquity: 자본변동표
+            dart-gcd_StatementOfCashFlows: 현금프름표
+        separate: bool, optional
+            True: 개별재무제표
+            False: 연결재무제표
+
+        Returns
+        -------
+        list of Table or None
+        """
+        tables = self.get_table_by_name(DATASET_TITLE[concept_id], separate=separate)
+        if tables is None:
+            return None
+        # 주석 Role(D851100 현금흐름표 주석 등)도 이름이 매칭되므로 본 재무제표 Role 번호로 필터링
+        role_numbers = get_statement_role_numbers(separate=separate)
+        tables = [table for table in tables
+                  if table.code is not None and table.code.upper() in role_numbers]
+        return tables if len(tables) > 0 else None
 
     def _get_statement(self, concept_id: str, separate: bool = False) -> Union[List[Table], None]:
         """ Financial statement information 을 이용하여 제공되는 재무제표를 추출하는 함수
@@ -303,14 +342,10 @@ class DartXbrl(object):
         if table is None:
             return None
         table_dict = table.get_value_by_concept_id(concept_id)
+        if not table_dict:
+            # D999007 Role은 존재하나 fact가 없는 공시 존재 (ex. rcept_no 20250318001434)
+            return self._get_statement_by_name(concept_id, separate=separate)
         compare_name = 'Separate' if separate else 'Consolidated'
-
-        dataset_title = {
-            'dart-gcd_StatementOfFinancialPosition': '재무상태표',
-            'dart-gcd_StatementOfComprehensiveIncome': '손익계산서',
-            'dart-gcd_StatementOfChangesInEquity': '자본변동표',
-            'dart-gcd_StatementOfCashFlows': '현금흐름표',
-        }
 
         try:
             for keys, value in table_dict.items():
@@ -321,7 +356,7 @@ class DartXbrl(object):
                         tables = [self.get_table_by_code(code) for code in code_list]
                         return tables
         except KeyError:
-            return self.get_table_by_name(dataset_title[concept_id], separate=separate)
+            return self._get_statement_by_name(concept_id, separate=separate)
         return None
 
     def get_financial_statement(self, separate: bool = False) -> Union[List[Table], None]:

--- a/dart_fss/xbrl/helper.py
+++ b/dart_fss/xbrl/helper.py
@@ -270,6 +270,43 @@ def generate_df_rows(labels, classification, dataset, max_depth,
 
 
 
+CONSOLIDATED_CODE_TO_ROLES = {
+    'D1001': ['D210000'],
+    'D1002': ['D220000'],
+    'D2001': ['D431410'],
+    'D2002': ['D431420'],
+    'D2003': ['D432410'],
+    'D2004': ['D432420'],
+    'D2005': ['D310000', 'D410000'],
+    'D2006': ['D310000', 'D420000'],
+    'D2007': ['D320000', 'D410000'],
+    'D2008': ['D320000', 'D420000'],
+    'D2009': ['D310000'],
+    'D2010': ['D320000'],
+    'D3001': ['D610000'],
+    'D4001': ['D510000'],
+    'D4002': ['D520000'],
+}
+
+SEPARATED_CODE_TO_ROLES = {
+    'D1001': ['D210005'],
+    'D1002': ['D220005'],
+    'D2001': ['D431415'],
+    'D2002': ['D431425'],
+    'D2003': ['D432415'],
+    'D2004': ['D432425'],
+    'D2005': ['D310005', 'D410005'],
+    'D2006': ['D310005', 'D420005'],
+    'D2007': ['D320005', 'D410005'],
+    'D2008': ['D320005', 'D420005'],
+    'D2009': ['D310005'],
+    'D2010': ['D320005'],
+    'D3001': ['D610005'],
+    'D4001': ['D510005'],
+    'D4002': ['D520005'],
+}
+
+
 def consolidated_code_to_role_number(code, separate=False):
     """ 코드번호를 Role 번호로 변환하는 함수
 
@@ -285,41 +322,26 @@ def consolidated_code_to_role_number(code, separate=False):
     list of str
         Role 번호 리스트
     """
-    consolidated_code = {
-        'D1001': ['D210000'],
-        'D1002': ['D220000'],
-        'D2001': ['D431410'],
-        'D2002': ['D431420'],
-        'D2003': ['D432410'],
-        'D2004': ['D432420'],
-        'D2005': ['D310000', 'D410000'],
-        'D2006': ['D310000', 'D420000'],
-        'D2007': ['D320000', 'D410000'],
-        'D2008': ['D320000', 'D420000'],
-        'D2009': ['D310000'],
-        'D2010': ['D320000'],
-        'D3001': ['D610000'],
-        'D4001': ['D510000'],
-        'D4002': ['D520000'],
-    }
-    separated_code = {
-        'D1001': ['D210005'],
-        'D1002': ['D220005'],
-        'D2001': ['D431415'],
-        'D2002': ['D431425'],
-        'D2003': ['D432415'],
-        'D2004': ['D432425'],
-        'D2005': ['D310005', 'D410005'],
-        'D2006': ['D310005', 'D420005'],
-        'D2007': ['D320005', 'D410005'],
-        'D2008': ['D320005', 'D420005'],
-        'D2009': ['D310005'],
-        'D2010': ['D320005'],
-        'D3001': ['D610005'],
-        'D4001': ['D510005'],
-        'D4002': ['D520005'],
-    }
-    return separated_code[code] if separate else consolidated_code[code]
+    # 미지원 코드는 KeyError를 그대로 전파해야 함 (DartXbrl._get_statement가 의존)
+    code_table = SEPARATED_CODE_TO_ROLES if separate else CONSOLIDATED_CODE_TO_ROLES
+    return code_table[code]
+
+
+def get_statement_role_numbers(separate=False):
+    """ 본 재무제표 Role 번호 집합을 반환하는 함수
+
+    Parameters
+    ----------
+    separate: bool, optional
+        개별재무제표 여부
+
+    Returns
+    -------
+    set of str
+        본 재무제표 Role 번호 집합
+    """
+    code_table = SEPARATED_CODE_TO_ROLES if separate else CONSOLIDATED_CODE_TO_ROLES
+    return {role for roles in code_table.values() for role in roles}
 
 
 def cls_datetime_check(cls, start_dt, end_dt):


### PR DESCRIPTION
This pull request introduces significant improvements to the handling and testing of financial statement extraction logic in the XBRL module, particularly around fallback mechanisms when key data is missing or incomplete. It refactors and centralizes the mapping logic for statement codes, adds comprehensive regression and edge-case tests, and improves robustness in determining the existence of consolidated statements.

### Improvements to XBRL statement extraction and fallback logic

* Added a new `_get_statement_by_name` method in `DartXbrl` to robustly retrieve financial statements by name and filter out annotation roles, used as a fallback when primary information is missing or empty.
* Enhanced the `_get_statement` and `exist_consolidated` methods to utilize the new fallback logic, improving handling for filings where the main info table (`D999007`) is missing or lacks facts. [[1]](diffhunk://#diff-c73cdf6192802318e0a2ed7d83291a7bc157cce9b4d573ea8de2a9273ca10ad3R282-R284) [[2]](diffhunk://#diff-c73cdf6192802318e0a2ed7d83291a7bc157cce9b4d573ea8de2a9273ca10ad3R345-L314) [[3]](diffhunk://#diff-c73cdf6192802318e0a2ed7d83291a7bc157cce9b4d573ea8de2a9273ca10ad3L324-R359)

### Refactoring and centralization of code mappings

* Refactored `consolidated_code_to_role_number` and related code mappings into top-level constants (`CONSOLIDATED_CODE_TO_ROLES`, `SEPARATED_CODE_TO_ROLES`) and added a new `get_statement_role_numbers` utility for retrieving valid statement role numbers. [[1]](diffhunk://#diff-18ccf6c55561b1dcb6e80805f8b45f7d2f5853746ec607e3c3a7f8f3c5e2b330L273-R273) [[2]](diffhunk://#diff-18ccf6c55561b1dcb6e80805f8b45f7d2f5853746ec607e3c3a7f8f3c5e2b330L305-R291) [[3]](diffhunk://#diff-18ccf6c55561b1dcb6e80805f8b45f7d2f5853746ec607e3c3a7f8f3c5e2b330L322-R344)

### Expanded and improved test coverage

* Added comprehensive regression and edge-case tests for fallback logic, code-to-role mapping, and existence checks for consolidated statements in `test_dart_xbrl.py` and `test_xbrl_helper.py`. These tests cover normal, missing, and ambiguous data scenarios. [[1]](diffhunk://#diff-a5d140d5d3ae36a008cb8da7833708cf24f62122373a0369062b804bd4eec173R64-R243) [[2]](diffhunk://#diff-da6cbd8569664493ab69c3f0adb285d66e3cbe06473e9b1b477d7bad09e26e7eR88-R106)
* Updated and clarified the error handling test in `test_errors.py` to use a stable lookup method, ensuring reliability regardless of stock code changes.

### Minor improvements

* Centralized the dataset title mapping in `dart_xbrl.py` for maintainability and clarity.

These changes make the XBRL extraction logic more robust to real-world filing inconsistencies and improve maintainability and test coverage.